### PR TITLE
Day 1 refactors/improvements

### DIFF
--- a/presentation/parts/logik.tex
+++ b/presentation/parts/logik.tex
@@ -145,6 +145,16 @@ Wir können Aussagen verändern oder durch Operationen zu neuen Aussagen verbind
     \item $A\implies B$ ist dieselbe Aussage wie $\neg A \vee B$
 \end{itemize}
 \end{alertblock}
+\onslide<2-|handout:1> {
+\metroset{block=fill}
+\begin{exampleblock}{Kontraposition}
+	\begin{itemize}
+		\item $\lnot B\implies \lnot A$ ist die Kontraposition zu $A \implies B$
+		\item ''Wenn B falsch ist, dann muss A auch falsch (gewesen) sein''
+		\item Die Implikation und ihre Kontraposition haben den selben Wahrheitswert
+	\end{itemize}
+\end{exampleblock}
+}
 \end{frame}
 
 {\setbeamercolor{palette primary}{bg=ExColor}
@@ -205,7 +215,7 @@ Wir können Aussagen verändern oder durch Operationen zu neuen Aussagen verbind
 		}
 		
 		\only<1>{Die Folgerung ist richtig. Laut Aussage ist Lukas im Vorkurs oder schläft noch (oder beides). Wenn er also nicht im Vorkurs ist, bleibt nur noch die Option übrig, dass er noch schläft.}
-		\only<2>{Die Folgerung ist richtig. Die zweite Aussage ist die Kontraposition der ersten Aussage. Wie gezeigt wurde, ist die Kontraposition einer Aussage wahr gdw. die Aussage selbst wahr ist. }
+		\only<2>{Die Folgerung ist richtig. Die zweite Aussage ist die Kontraposition der ersten Aussage. Die Kontraposition einer Aussage ist wahr gdw. die Aussage selbst wahr ist. }
 		\only<3>{Die Folgerung ist falsch. Es ist auch möglich, dass Tobi lernt und nicht besteht!}
 	\end{frame}
 }

--- a/presentation/parts/logik.tex
+++ b/presentation/parts/logik.tex
@@ -250,7 +250,8 @@ Wir können Aussagen verändern oder durch Operationen zu neuen Aussagen verbind
         \item $A_5$: $(a \notin \emptyset) \implies (\emptyset = \emptyset^{*})$
         \item $A_6$: $A_4 \iff A_5$
         \item $A_7$: $(7 \in \{1, 2, 7, 9\}) \cap (2 = 7-5)$
-        \item $A_8$: Wenn mein Auto fliegt, dann hast du auch ein fliegendes Auto.
+        \item $A_8$: Wenn die Erde zwei Monde hat,\\
+		\quad dann ist die Erde der innerste Planet zur Sonne.
     \end{itemize}
     \end{block}
 \end{frame}

--- a/presentation/parts/sprachen-intro.tex
+++ b/presentation/parts/sprachen-intro.tex
@@ -122,11 +122,12 @@
         \item Wort der Länge 3: z.B. $aaa, aba, 110, \text{RechtsPauseStopp} \dots$
         \item Wort der Länge 2: z.B. $aa, ab, 00, \text{StartVorw"arts} \dots$
         \item Wort der Länge 1: z.B. $a, b, 1, \text{Links} \dots$
-        \item Wort der Länge \alert<2>{0}: \alert<2>{$\emptyWord$}
+        \item Wort der Länge \alert<3>{0}: \alert<3>{$\emptyWord$}
     \end{itemize}
-    \only<1>{Wir schreiben \alert<1>{$\absval{w}$} um \alert<1>{Länge des Wortes $w$} abzukürzen.\\}
-    \only<2->{$\emptyWord$ \emph{(\glqq Epsilon\grqq)} nennen wir das \glqq leere Wort\grqq.}
-    \onslide<2->{\begin{itemize}
+    \only<1-2>{Wir schreiben \alert<1>{$\absval{w}$} um \alert<1>{Länge des Wortes $w$} abzukürzen.\\}
+    \only<2>{Um \alert<2>{nur ein Symbol} (z.B. $a$) zu zählen verwenden wir \alert<2>{$|w|_a$}.\\}
+    \only<3->{$\emptyWord$ \emph{(\glqq Epsilon\grqq)} nennen wir das \glqq leere Wort\grqq.}
+    \onslide<3->{\begin{itemize}
         \item \alert{Vergleich:} Es ist vergleichbar mit einem leerem String,\\ \qquad\qquad \,\, also: $\dq\dq=\emptyWord$
         \item \alert{Achtung:} Das leere Wort kann kein Teil eines Alphabets sein,\\\qquad\qquad da es nicht einstellig ist. Es hat die Wortl"ange $|\varepsilon|=0$
     \end{itemize}}

--- a/presentation/parts/sprachen-intro.tex
+++ b/presentation/parts/sprachen-intro.tex
@@ -119,16 +119,16 @@
         Eine endlich lange Kette an Symbolen aus dem Alphabet nennen wir ein Wort.
     \end{alertblock}
     \begin{itemize}
-        \item Wort der Länge 3: z.B. $aaa, abc, \dots$
-        \item Wort der Länge 2: z.B. $aa, ab, \dots$
-        \item Wort der Länge 1: z.B. $a, b, c, \dots$
+        \item Wort der Länge 3: z.B. $aaa, aba, 110, \text{RechtsPauseStopp} \dots$
+        \item Wort der Länge 2: z.B. $aa, ab, 00, \text{StartVorw"arts} \dots$
+        \item Wort der Länge 1: z.B. $a, b, 1, \text{Links} \dots$
         \item Wort der Länge \alert<2>{0}: \alert<2>{$\emptyWord$}
     \end{itemize}
     \only<1>{Wir schreiben \alert<1>{$\absval{w}$} um \alert<1>{Länge des Wortes $w$} abzukürzen.\\}
     \only<2->{$\emptyWord$ \emph{(\glqq Epsilon\grqq)} nennen wir das \glqq leere Wort\grqq.}
     \onslide<2->{\begin{itemize}
         \item \alert{Vergleich:} Es ist vergleichbar mit einem leerem String,\\ \qquad\qquad \,\, also: $\dq\dq=\emptyWord$
-        \item \alert{Achtung:} Das leere Wort kann kein Teil eines Alphabets sein,\\\qquad\qquad da es nicht einstellig ist.
+        \item \alert{Achtung:} Das leere Wort kann kein Teil eines Alphabets sein,\\\qquad\qquad da es nicht einstellig ist. Es hat die Wortl"ange $|\varepsilon|=0$
     \end{itemize}}
 \end{frame}
 


### PR DESCRIPTION
- Block Kontrposition bei Einführugn der Implikation (noch ohne Beweis)
- Wortlänge von $\varepsilon$ verdeutlicht
- Beispiele für Wörter mit Symbolen mit >1 Buchstaben
- $|w|_a$ auf Folie mit Wortlängen eingeführt

Closes #35 
Closes #31 
Closes #32 
Closes #17 