### PR TITLE
QR-Code auf die Titelseite

### DIFF
--- a/presentation/config.tex
+++ b/presentation/config.tex
@@ -24,3 +24,6 @@
 
 % Invite URL to the Ersti-Telegram-Group. Used for text on slide as well as QR-Code
 \newcommand\telegramurl{https://t.me/+Q92w5biyY903NjEy}
+
+% The url to the handout of the current day with the current day as argument. Used for the qr-code in the slides. 
+\newcommand{\handouturl}[1]{https://fius.de/wp-content/uploads/2022/10/day-#1-handout.pdf}

--- a/presentation/parts/title.tex
+++ b/presentation/parts/title.tex
@@ -15,6 +15,36 @@
 % You should have received a copy of the GNU General Public License
 % along with theo-vorkurs-folien.  If not, see <https://www.gnu.org/licenses/>.
 
+% This sets the template for the titlepage. 
+% Only change to the default is that the titlegraphic is not in the left upper but in the right lower corner
+\setbeamertemplate{title page}{
+    \begin{minipage}[b][\paperheight]{\textwidth}
+    \vfill%
+    \ifx\inserttitle\@empty
+    \else\usebeamertemplate*{title}
+    \fi
+    \ifx\insertsubtitle\@empty
+    \else\usebeamertemplate*{subtitle}
+    \fi
+    \usebeamertemplate*{title separator}
+    \ifx\beamer@shortauthor\@empty
+    \else\usebeamertemplate*{author}
+    \fi
+    \ifx\insertdate\@empty
+    \else\usebeamertemplate*{date}
+    \fi
+    \ifx\insertinstitute\@empty
+    \else\usebeamertemplate*{institute}
+    \fi
+    \ifx\inserttitlegraphic\@empty
+    \else{\hfill\inserttitlegraphic\hspace{.1\textwidth}}
+    \fi
+    \vfill
+    \vspace*{1mm}
+    \end{minipage}
+}
+
+
 \title{Vorkurs Theoretische Informatik}
 
 \if\daynr1
@@ -48,3 +78,12 @@
 \author{Arbeitskreis Theo-Vorkurs}
 \institute{\href{https://fius.de}{Fachgruppe Informatik Universität Stuttgart}}
 % \titlegraphic{\hfill\includegraphics[height=1.5cm]{logo.pdf}}
+
+% sets the qr-code to the current handout slides on the title page. 
+% This can be changed to let the qr-code appear on every page by exchanging \titlegraphic with \logo.
+\titlegraphic{
+    \fbox{\parbox{2cm+.5em}{\centering
+        Aktuelle Folien:\par \vspace{.5ex}
+        \qrcode{\handouturl{\daynr}}
+    }}
+}


### PR DESCRIPTION
Hinzugefügt:

- Befehl um den Link zum Handout für den aktuellen Tag zu bekommen
- QR-Code auf die Titelseite

Geändert:
- Das Template der Titlepage. Die `titlegraphic` ist jetzt nicht mehr oben im Eck sondern unten rechts
