### PR TITLE
Formatierung der Induktionsbeweise Tag 3

### DIFF
--- a/presentation/parts/induktion-1.tex
+++ b/presentation/parts/induktion-1.tex
@@ -19,7 +19,7 @@
 \begin{frame}[fragile]{Idee}
 \begin{columns}
 \column{0.5\textwidth}
-    \begin{alertblock}{Zeige Aussagen der Form:\\\emph{Für alle $n\in\mathbb{N}$ gilt...}}
+    \begin{alertblock}{Zeige Aussagen der Form:\\\emph{Für alle $n\in\mathbb{N}$ gilt\ldots}}
     \begin{enumerate}
         \item Zeige Aussage für das kleinste Element
         \item<1-> \only<7,8|handout:0>{\alert<7>{Zeige, wenn Aussage für beliebiges $n$ gilt, gilt sie auch für dessen Nachfolger, also $n+1$.}}\onslide<1-6>{Zeige, dass Aussage auch für das folgende Element gilt.}
@@ -42,7 +42,7 @@
 
 \subsubsection{Funktionsweise}
 \begin{frame}[fragile]{Struktur}
-    \begin{alertblock}{Zeige Aussagen der Form:\\\emph{Für alle $n\in\mathbb{N}$ gilt...}}
+    \begin{alertblock}{Zeige Aussagen der Form:\\\emph{Für alle $n\in\mathbb{N}$ gilt\ldots}}
     \begin{enumerate}
         \item \alert{Induktionsanfang}\\Zeige Aussage für das kleinste Element
         \item \alert{Induktionsvorraussetzung}\\Zeige, unter der Vorraussetzung: \\\emph{die Aussage gelte für beliebiges $n$},\dots
@@ -62,7 +62,7 @@
     \end{figure}
 \end{frame}
 \note[itemize]{
-    \item Idee: Es werden 1, 3, 5, ... Felder hinzugenommen
+    \item Idee: Es werden 1, 3, 5, \ldots Felder hinzugenommen
     \item Lässt sich jeweils zu einem Quadrat zusammensetzen
     \item Mit jedem Schritt wird Kantenlänge des Quadrats um eins größer
 }
@@ -72,9 +72,9 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2,\quad\forall n \in\ma
 \begin{alertblock}{Induktionsanfang (IA)}
     Zeige Aussage gilt für $n\defeq0$:\\
     \begin{align*}
-        \sum_{i = 0}^{0} (2i+1) &\overset{!}{=} (0+1)^2\\
-        \iff 2 \cdot 0 + 1 &\overset{!}{=}1^2\\
-        \iff 1 &= 1 \qquad\checkmark
+        &\sum_{i = 0}^{0} (2i+1)& &\overset{!}{=}& &(0+1)^2&\\
+        \iffspace &2 \cdot 0 + 1& &\overset{!}{=}& &1^2&\\
+        \iffspace &1& &=& &1& \qquad\checkmark
     \end{align*}
 \end{alertblock}
 \end{frame}
@@ -82,42 +82,42 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2,\quad\forall n \in\ma
 \begin{frame}[fragile]{Beispiel}
 Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2,\quad\forall n \in\mathbb{N}$.
 \begin{alertblock}{Induktionsanfang (IA)}
-    Aussage gilt für $n\defeq0$, da $\sum_{i = 0}^{0} (2i+1) = (0+1)^2$
+    Aussage gilt für $n\defeq0$, da $\displaystyle\sum_{i = 0}^{0} (2i+1) = (0+1)^2$.
 \end{alertblock}
 \begin{alertblock}{Induktionsvorraussetzung (IV)}
     Ang. Aussage gilt für $n \in\mathbb{N}$.
 \end{alertblock}
 \begin{alertblock}{Induktionsschritt (IS)}
-    Zeige Aussage gilt für alle $n+1$ unter Nutzung der (IV):\\
-    $\sum_{i = 0}^{\alert{n+1}} (2i+1) \overset{!}{=} (\alert{(n+1)}+1)^2$
+    Zeige Aussage gilt für alle $n+1$ unter Nutzung der (IV):\par
+    $\displaystyle\sum_{i = 0}^{\alert{n+1}} (2i+1) \overset{!}{=} (\alert{(n+1)}+1)^2$
 \end{alertblock}
 \end{frame}
 
 \begin{frame}[fragile]{Beispiel}
 \small\begin{alertblock}{Induktionsschritt}
-    Zeige Aussage gilt für alle $n+1$ unter Nutzung der IV:
+    Zeige Aussage gilt für alle $n+1$ unter Nutzung der IV:\@
     \begin{align*}
-        \onslide<1->{&\sum_{i = 0}^{n+1} (2i+1)&\overset{!}{=}&\ ((n+1)+1)^2}\\
-        \onslide<2->{\iff&\sum_{i = 0}^{\alert<2>{n}} (2i+1) + \sum_{i = \alert<2>{n+1}}^{n+1} (2i+1)&\ \overset{!}{=}& (n+2)^2}\\
-        \onslide<3->{\iff&\sum_{i = 0}^{n} (2i+1) + ( 2(n+1)+1 )&\overset{!}{=}&\ n^2 + 2 \cdot 2n + 2^2}\\
-        \onslide<4->{\overset{\alert<4>{IV}}\iff&\alert<4>{(n+1)^2} + ( 2(n+1)+1 )&\overset{!}{=}&\ n^2+4n+4}\\
-        \onslide<5->{\iff&n^2+2n+1^2+2n+2+1&\overset{!}{=}&\ n^2+4n+4}\\
-        \onslide<6>{\iff&n^2+4n+4&\alert<6>{=}&\ n^2+4n+4}
+        \onslide<1->{&\sum_{i = 0}^{n+1} (2i+1)& &\overset{!}{=}& &((n+1)+1)^2&}\\
+        \onslide<2->{\iffspace &\sum_{i = 0}^{\alert<2>{n}} (2i+1) + \sum_{i = \alert<2>{n+1}}^{n+1} (2i+1)& &\overset{!}{=}& &(n+2)^2&}\\
+        \onslide<3->{\iffspace &\sum_{i = 0}^{n} (2i+1) + ( 2(n+1)+1 )& &\overset{!}{=}& &n^2 + 2 \cdot 2n + 2^2&}\\
+        \onslide<4->{\overset{\alert<4>{IV}}\iffspace &\alert<4>{(n+1)^2} + ( 2(n+1)+1 )& &\overset{!}{=}& &n^2+4n+4&}\\
+        \onslide<5->{\iffspace &n^2+2n+1^2+2n+2+1& &\overset{!}{=}& &n^2+4n+4&}\\
+        \onslide<6>{\iffspace &n^2+4n+4& &\alert<6>{=}& &n^2+4n+4&}
     \end{align*}
 \end{alertblock}
 \end{frame}
 
 \begin{frame}[fragile]{Beispiel}
-Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\mathbb{N}$.
+Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2, \quad\forall n \in\mathbb{N}$.
 \begin{alertblock}{Induktionsanfang (IA)}
-    Aussage gilt für $n\defeq0$, da $\sum_{i = 0}^{0} (2i+1) = 1^2$
+    Aussage gilt für $n\defeq0$, da $\displaystyle\sum_{i = 0}^{0} (2i+1) = 1^2$.
 \end{alertblock}
 \begin{alertblock}{Induktionsvorraussetzung (IV)}
     Ang. Aussage gilt für ein (beliebiges aber festes) $n \in\mathbb{N}$.
 \end{alertblock}
 \begin{alertblock}{Induktionsschritt (IS)}
-    Aussage gilt für alle $n+1$ unter Nutzung der IV, da\\
-    $\sum_{i = 0}^{n+1} (2i+1) = ((n+1)+1)^2$
+    Aussage gilt für alle $n+1$ unter Nutzung der IV, da\par
+    $\displaystyle\sum_{i = 0}^{n+1} (2i+1) = ((n+1)+1)^2$
 \end{alertblock}
 \alert{$\leadsto$ Aussage gilt für alle n.}\qed
 \end{frame}
@@ -131,10 +131,10 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
 
     \metroset{block=fill}
     \begin{block}{Normal}
-        $\displaystyle\sum_{i=0}^{n} i = \frac{n(n+1)}{2} \quad \forall n \in \mathbb{N}$
+        $\displaystyle\sum_{i=0}^{n} i = \frac{n(n+1)}{2}, \quad \forall n \in \mathbb{N}$
     \end{block}
     \begin{block}{Schwerer}
-        $\displaystyle\prod_{i=1}^{n} 4^i = 2^{n(n+1)} \quad \forall n \in \mathbb{N}\setminus \{0\}$
+        $\displaystyle\prod_{i=1}^{n} 4^i = 2^{n(n+1)}, \quad \forall n \in \mathbb{N}\setminus \{0\}$
     \end{block}
 \end{frame}
 }
@@ -150,7 +150,7 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
         Ang. Aussage gilt für $n \in\mathbb{N}$.
     \end{alertblock}
     \begin{alertblock}{Induktionsschritt (IS)}
-        Zeige Aussage gilt für alle $n+1$ unter Nutzung der IV:\\
+        Zeige Aussage gilt für alle $n+1$ unter Nutzung der IV:\par
         $\displaystyle\sum_{i=0}^{\alert{n+1}} i \overset{!}{=} \frac{(\alert{n+1})\left((\alert{n+1})+1\right)}{2}$
     \end{alertblock}
 \end{frame}
@@ -160,12 +160,12 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
 \small\begin{alertblock}{Induktionsschritt}
     Zeige Aussage gilt für $n+1$ unter Nutzung der I.V.:
     \begin{align*}
-        \onslide<1->{&\displaystyle\sum_{i=0}^{\alert<1>{n+1}} i &\overset{!}{=}&\ \frac{(\alert<1>{n+1})\left((\alert<1>{n+1})+1\right)}{2}}\\
-        \onslide<2->{\iff&\left(\displaystyle\sum_{i=0}^{n} i\right)+(n+1) &\overset{!}{=}&\ \frac{(n+1)(n+2)}{2}}\\
-        \onslide<3->{\iff&\left(\displaystyle\sum_{i=0}^{n} i\right)+(n+1) &\overset{!}{=}&\ \frac{n^2+3n+2}{2}}\\
-        \onslide<4->{\overset{\alert<4>{IV}}\iff&\alert<4>{\frac{n(n+1)}{2}}+(n+1) &\overset{!}{=}&\ \frac{n^2+3n+2}{2}}\\
-        \onslide<5->{\iff&\frac{n^2+n}{2}+\frac{2n+2}{2} &\overset{!}{=}&\ \frac{n^2+3n+2}{2}}\\
-        \onslide<6->{\iff&\frac{n^2+3n+2}{2} &\alert{=}&\ \frac{n^2+3n+2}{2}}\\
+        \onslide<1->{&\displaystyle\sum_{i=0}^{\alert<1>{n+1}} i& &\overset{!}{=}& &\frac{(\alert<1>{n+1})\left((\alert<1>{n+1})+1\right)}{2}&}\\
+        \onslide<2->{\iffspace &\left(\displaystyle\sum_{i=0}^{n} i\right)+(n+1)& &\overset{!}{=}& &\frac{(n+1)(n+2)}{2}&}\\
+        \onslide<3->{\iffspace &\left(\displaystyle\sum_{i=0}^{n} i\right)+(n+1)& &\overset{!}{=}& &\frac{n^2+3n+2}{2}&}\\
+        \onslide<4->{\overset{\alert<4>{IV}}\iffspace &\alert<4>{\frac{n(n+1)}{2}}+(n+1)& &\overset{!}{=}& &\frac{n^2+3n+2}{2}&}\\
+        \onslide<5->{\iffspace &\frac{n^2+n}{2}+\frac{2n+2}{2}& &\overset{!}{=}& &\frac{n^2+3n+2}{2}&}\\
+        \onslide<6->{\iffspace &\frac{n^2+3n+2}{2}& &\alert{=}& &\frac{n^2+3n+2}{2}&}\\
     \end{align*}
 \end{alertblock}
 \end{frame}
@@ -180,7 +180,7 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
         Ang. Aussage gilt für $n \in\mathbb{N}$.
     \end{alertblock}
     \begin{alertblock}{Induktionsschritt (IS)}
-        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\\
+        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\par
         $\displaystyle\sum_{i=0}^{\alert{n+1}} i \overset{!}{=} \frac{(\alert{n+1})\left((\alert{n+1})+1\right)}{2}$ gilt für alle $n \in \mathbb{N}$
     \end{alertblock}
     \alert{$\leadsto$ Aussage gilt für alle $n$.}\qed
@@ -202,7 +202,7 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
         Ang. Aussage gilt für $n \in\mathbb{N}\setminus \{0\}$.
     \end{alertblock}
     \begin{alertblock}{Induktionsschritt (IS)}
-        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\\
+        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\par
         $\displaystyle\prod_{i=1}^{\alert{n+1}} 4^i \overset{!}{=} 2^{(\alert{n+1})((\alert{n+1})+1)}$
     \end{alertblock}
 \end{frame}
@@ -211,13 +211,13 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
 \small\begin{alertblock}{Induktionsschritt}
     Zeige Aussage gilt für $n+1$ unter Nutzung der I.V.:
     \begin{align*}
-        \onslide<1->{&\displaystyle\prod_{i=1}^{\alert<1>{n+1}} 4^i &\overset{!}{=}&\ 2^{(\alert<1>{n+1})((\alert<1>{n+1})+1)}}\\
-        \onslide<2->{\iff&\left(\displaystyle\prod_{i=1}^{n} 4^i\right) \cdot 4^{(n+1)} &\overset{!}{=}&\ 2^{(n+1)(n+2)}}\\
-        \onslide<3->{\overset{\alert<3>{IV}}\iff&\alert<3>{\left(2^{n(n+1)}\right)} \cdot 4^{(n+1)} &\overset{!}{=}&\ 2^{n^2+3n+2}}\\
-        \onslide<4->{\iff&2^{n^2+n} \cdot 2^{2(n+1)} &\overset{!}{=}&\ 2^{n^2+3n+2}}\\
-        \onslide<5->{\iff&2^{n^2+n} \cdot 2^{2n+2} &\overset{!}{=}&\ 2^{n^2+3n+2}}\\
-        \onslide<6->{\iff&2^{(n^2+n)+(2n+2)} &\overset{!}{=}&\ 2^{n^2+3n+2}}\\
-        \onslide<7->{\iff&2^{n^2+3n+2} &\alert{=}&\ 2^{n^2+3n+2}}
+        \onslide<1->{&\displaystyle\prod_{i=1}^{\alert<1>{n+1}} 4^i& &\overset{!}{=}& &2^{(\alert<1>{n+1})((\alert<1>{n+1})+1)}&}\\
+        \onslide<2->{\iffspace &\left(\displaystyle\prod_{i=1}^{n} 4^i\right) \cdot 4^{(n+1)}& &\overset{!}{=}& &2^{(n+1)(n+2)}&}\\
+        \onslide<3->{\overset{\alert<3>{IV}}\iffspace &\alert<3>{\left(2^{n(n+1)}\right)} \cdot 4^{(n+1)}& &\overset{!}{=}& &2^{n^2+3n+2}&}\\
+        \onslide<4->{\iffspace &2^{n^2+n} \cdot 2^{2(n+1)}& &\overset{!}{=}& &2^{n^2+3n+2}&}\\
+        \onslide<5->{\iffspace &2^{n^2+n} \cdot 2^{2n+2}& &\overset{!}{=}& &2^{n^2+3n+2}&}\\
+        \onslide<6->{\iffspace &2^{(n^2+n)+(2n+2)}& &\overset{!}{=}& &2^{n^2+3n+2}&}\\
+        \onslide<7->{\iffspace &2^{n^2+3n+2}& &\alert{=}& &2^{n^2+3n+2}&}
     \end{align*}
 \end{alertblock}
 \end{frame}
@@ -232,7 +232,7 @@ Zeigen Sie $\displaystyle\sum_{i = 0}^{n} (2i+1) = (n+1)^2 \quad\forall n \in\ma
         Ang. Aussage gilt für $n \in\mathbb{N}\setminus \{0\}$.
     \end{alertblock}
     \begin{alertblock}{Induktionsschritt (IS)}
-        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\\
+        Zeige Aussage gilt für $n+1$ unter Nutzung der IV:\par
         $\displaystyle\prod_{i=1}^{\alert{n+1}} 4^i \overset{!}{=} 2^{(\alert{n+1})((\alert{n+1})+1)}$ gilt für alle $n \in \mathbb{N}\setminus \{0\}$
     \end{alertblock}
     \alert{$\leadsto$ Aussage gilt für alle $n$.}\qed

--- a/presentation/preamble.tex
+++ b/presentation/preamble.tex
@@ -77,6 +77,7 @@
 \newcommand{\integers}{\ensuremath{\mathbb{Z}}}
 \newcommand{\rationals}{\ensuremath{\mathbb{Q}}}
 \newcommand{\reals}{\ensuremath{\mathbb{R}}}
+\newcommand{\iffspace}{\ensuremath{\iff\;}}
 
 \setbeamertemplate{footline}[text line]
 {\parbox{\linewidth}{Fachgruppe Informatik\hfill\insertpagenumber\hfill Vorkurs Theoretische Informatik\vspace{0.2in}}}

--- a/presentation/preamble.tex
+++ b/presentation/preamble.tex
@@ -77,7 +77,7 @@
 \newcommand{\integers}{\ensuremath{\mathbb{Z}}}
 \newcommand{\rationals}{\ensuremath{\mathbb{Q}}}
 \newcommand{\reals}{\ensuremath{\mathbb{R}}}
-\newcommand{\iffspace}{\ensuremath{\iff\;}}
+\newcommand{\iffspace}{\ensuremath{\iff\ }}
 
 \setbeamertemplate{footline}[text line]
 {\parbox{\linewidth}{Fachgruppe Informatik\hfill\insertpagenumber\hfill Vorkurs Theoretische Informatik\vspace{0.2in}}}


### PR DESCRIPTION
Geändert:
- IS bei den Induktionsbeweis-Beispielen und -Lösungen mit mehr Platz ausgerichtet.
- Die Zeichensetzung und der `displaystyle` im kompletten Teil der Induktion von Tag 3 konsistenter gemacht.
- Neuen Befehl `\iffspace`, der einem `\iff` mit ein bisschen Platz dahinter zurück gibt.

Closes #65